### PR TITLE
feat: add unfrl/dug

### DIFF
--- a/pkgs/unfrl/dug/pkg.yaml
+++ b/pkgs/unfrl/dug/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: unfrl/dug@0.0.92
+  - name: unfrl/dug
+    version: 0.0.75
+  - name: unfrl/dug
+    version: 0.0.74

--- a/pkgs/unfrl/dug/registry.yaml
+++ b/pkgs/unfrl/dug/registry.yaml
@@ -1,0 +1,56 @@
+packages:
+  - type: github_release
+    repo_owner: unfrl
+    repo_name: dug
+    description: A global DNS propagation checker that gives pretty output. Written in dotnet core
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.74")
+        asset: dug-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: osx
+        overrides:
+          - goos: linux
+            goarch: amd64
+            format: tar.gz
+            asset: dug.{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            asset: dug
+      - version_constraint: Version == "0.0.75"
+        asset: dug.{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: osx
+        overrides:
+          - goos: linux
+            goarch: arm64
+            format: raw
+            asset: dug-{{.OS}}-{{.Arch}}
+          - goos: darwin
+            asset: dug.0.0.1.{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: raw
+            asset: dug
+      - version_constraint: "true"
+        asset: dug.{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: osx
+        overrides:
+          - goos: linux
+            goarch: arm64
+            format: raw
+            asset: dug-{{.OS}}-{{.Arch}}
+          - goos: windows
+            format: raw
+            asset: dug

--- a/registry.yaml
+++ b/registry.yaml
@@ -43437,6 +43437,61 @@ packages:
           - goos: windows
             format: zip
   - type: github_release
+    repo_owner: unfrl
+    repo_name: dug
+    description: A global DNS propagation checker that gives pretty output. Written in dotnet core
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.74")
+        asset: dug-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: osx
+        overrides:
+          - goos: linux
+            goarch: amd64
+            format: tar.gz
+            asset: dug.{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            asset: dug
+      - version_constraint: Version == "0.0.75"
+        asset: dug.{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: osx
+        overrides:
+          - goos: linux
+            goarch: arm64
+            format: raw
+            asset: dug-{{.OS}}-{{.Arch}}
+          - goos: darwin
+            asset: dug.0.0.1.{{.OS}}-{{.Arch}}.{{.Format}}
+          - goos: windows
+            format: raw
+            asset: dug
+      - version_constraint: "true"
+        asset: dug.{{.Version}}.{{.OS}}-{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        replacements:
+          amd64: x64
+          darwin: osx
+        overrides:
+          - goos: linux
+            goarch: arm64
+            format: raw
+            asset: dug-{{.OS}}-{{.Arch}}
+          - goos: windows
+            format: raw
+            asset: dug
+  - type: github_release
     repo_owner: updatecli
     repo_name: updatecli
     asset: updatecli_{{.OS}}_{{.Arch}}.{{.Format}}


### PR DESCRIPTION
[unfrl/dug](https://github.com/unfrl/dug): A global DNS propagation checker that gives pretty output. Written in dotnet core

```console
$ aqua g -i unfrl/dug
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [ ] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ dug www.google.com
```

If files such as configuration file are needed, please share them.

Reference

-
